### PR TITLE
fix: prevent account-switch cold launch splash hang

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -77,7 +77,7 @@ const config = {
                 constModules: {
                   globals: {
                     "bunny-build-info": {
-                      version: `"1.4.1.7"`,
+                      version: `"1.4.1.8"`,
                     },
                   },
                 },

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -11,7 +11,7 @@ async function initializeShiggyCord() {
     Object.freeze = Object.seal = Object;
 
     await require("@metro/internals/caches").initMetroCache();
-    await require(".").default();
+    require(".").default();
   } catch (e) {
     const { ClientInfoManager } = require("@lib/api/native/modules");
     const stack = e instanceof Error ? e.stack : undefined;


### PR DESCRIPTION
Fixes #13.

ShiggyCord currently waits for the full main initializer to resolve before allowing Discord startup to continue. After an account switch, this can leave the first subsequent cold launch stuck indefinitely on the splash screen.

Removing the await from the main initializer allows Discord startup to continue while ShiggyCord initialization completes, matching the equivalent startup behavior upstream.

Tested repeatedly with: account switch → force close → first cold reopen. The first reopen succeeds with this change.

Also bumps the ShiggyCord version to 1.4.1.8 as requested.